### PR TITLE
Centralize frameworks and update testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Manage the lifecycle of servers carefully:
 - Stop the SSE server when the engine shuts down and clear static references.
 - Use Conventional Commit messages with an emoji.
-- Always run `dotnet test NetfxMcp.Tests/NetfxMcp.Tests.csproj` before committing.
+- Always run `dotnet test FluxMcp.sln` before committing.
 - Build and test commands run offline once packages are restored. Restoring new packages requires network access.
 - Avoid splitting property values containing paths with spaces across lines, as it can cause path resolution failures.
 - Use `.editorconfig` for configuring compiler warnings and code style settings across the entire solution.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,16 @@
 <Project>
   <!-- Basic build settings -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildProjectName)' == 'NetfxMcp.Tests'">
+    <TargetFrameworks>net472;net9.0</TargetFrameworks>
+    <TargetFramework></TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>

--- a/NetfxMcp.Tests/NetfxMcp.Tests.csproj
+++ b/NetfxMcp.Tests/NetfxMcp.Tests.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.0-preview.3.25171.5" />
   </ItemGroup>

--- a/ResoniteStubs/ResoniteStubs.csproj
+++ b/ResoniteStubs/ResoniteStubs.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>ResoniteStubs</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- manage target frameworks in `Directory.Build.props`
- rely on global settings for `NetfxMcp.Tests` and `ResoniteStubs`
- update `AGENTS.md` to run tests for the entire solution

## Testing
- `dotnet test FluxMcp.sln -v minimal` *(fails: no route to host)*