### PR TITLE
Remove unused refs and centralize packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <DelaySign>False</DelaySign>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <!-- Code quality and analysis settings -->
@@ -72,25 +73,25 @@
   <!-- Common package references -->
   <ItemGroup>
     <!-- Code analysis -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
     <!-- Runtime -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>
 
   <!-- Test-specific packages -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest" Version="3.6.4" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="MSTest" Version="3.6.4" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0-preview.3.25171.5" />
+    <PackageVersion Include="System.IO.Pipelines" Version="9.0.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+  </ItemGroup>
+</Project>

--- a/FluxMcp.Tests/FluxMcp.Tests.csproj
+++ b/FluxMcp.Tests/FluxMcp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <ProjectReference Include="..\FluxMcp\FluxMcp.csproj" />
   </ItemGroup>
 

--- a/FluxMcp/FluxMcp.csproj
+++ b/FluxMcp/FluxMcp.csproj
@@ -11,11 +11,9 @@
 
   <ItemGroup>
     <None Include=".github\**\" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
-    <PackageReference Include="System.Threading.Channels" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.IO.Pipelines" />
+    <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Text.Json" />
 
   </ItemGroup>
 

--- a/NetfxMcp.Tests/NetfxMcp.Tests.csproj
+++ b/NetfxMcp.Tests/NetfxMcp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>
   <Import Project="..\NetfxMcp\NetfxMcp.projitems" Label="Shared" />
 </Project>

--- a/ResoniteMod.props
+++ b/ResoniteMod.props
@@ -5,17 +5,9 @@
     <ResoniteAssemblyPrivate Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">False</ResoniteAssemblyPrivate>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="Exists('$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll')">
     <Reference Include="FrooxEngine">
       <HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
-      <Private>$(ResoniteAssemblyPrivate)</Private>
-    </Reference>
-    <Reference Include="ProtoFlux.Core">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\ProtoFlux.Core.dll</HintPath>
-      <Private>$(ResoniteAssemblyPrivate)</Private>
-    </Reference>
-    <Reference Include="ProtoFluxBindings">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\ProtoFluxBindings.dll</HintPath>
       <Private>$(ResoniteAssemblyPrivate)</Private>
     </Reference>
     <Reference Include="Elements.Core">
@@ -33,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="!Exists('$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll')">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)ResoniteStubs\ResoniteStubs.csproj" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.0-preview.3.25171.5" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)ResoniteStubs\ResoniteStubs.csproj" ReferenceOutputAssembly="true" />
+    <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- enable central package management
- remove unused ProtoFlux assemblies
- centralize package versions

## Testing
- `dotnet test FluxMcp.sln -v minimal -clp:DisableConsoleColor` *(fails: missing Resonite references)*