### PR TITLE
Fix tests by adjusting stubs and cleanup

### DIFF
--- a/FluxMcp.Tests/McpFakeToolTests.cs
+++ b/FluxMcp.Tests/McpFakeToolTests.cs
@@ -106,8 +106,15 @@ public sealed class McpFakeToolTests : IDisposable
         if (_serverCts != null)
         {
             _serverCts.Cancel();
-            _server.Stop();
-            await _serverTask.ConfigureAwait(false);
+            try
+            {
+                _server.Stop();
+                await _serverTask.ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Server already disposed
+            }
         }
     }
 

--- a/FluxMcp/FluxMcpMod.cs
+++ b/FluxMcp/FluxMcpMod.cs
@@ -104,11 +104,18 @@ public partial class FluxMcpMod : ResoniteMod
 
         try
         {
-            _httpServer.Stop();
             _cts?.Cancel();
-            _serverTask?.GetAwaiter().GetResult();
+            try
+            {
+                _httpServer.Stop();
+                _serverTask?.GetAwaiter().GetResult();
+                _httpServer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Server already disposed
+            }
             _cts?.Dispose();
-            _httpServer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
         finally
         {

--- a/ResoniteStubs/Stubs.cs
+++ b/ResoniteStubs/Stubs.cs
@@ -24,12 +24,20 @@ namespace ResoniteModLoader
 
     public class ModConfiguration
     {
-        public T? GetValue<T>(ModConfigurationKey<T> key) => default;
+        public T? GetValue<T>(ModConfigurationKey<T> key)
+            => key?.ComputeDefault != null ? key.ComputeDefault() : default;
     }
 
     public class ModConfigurationKey<T>
     {
-        public ModConfigurationKey(string name, System.Func<T>? computeDefault = null) { }
+        public ModConfigurationKey(string name, System.Func<T>? computeDefault = null)
+        {
+            Name = name;
+            ComputeDefault = computeDefault;
+        }
+
+        public string Name { get; }
+        internal System.Func<T>? ComputeDefault { get; }
         public event System.Action<T?>? OnChanged;
     }
 
@@ -79,7 +87,7 @@ namespace FrooxEngine
     {
         private int _id;
         public RefID(int id) { _id = id; }
-        public override string ToString() => $"ID{_id}";
+        public override string ToString() => $"ID{_id:X}";
         public static bool TryParse(string? s, out RefID id)
         {
             if (s != null && s.StartsWith("ID") && int.TryParse(s.Substring(2), out var v))


### PR DESCRIPTION
## Summary
- fix configuration default values in stubs
- make server cleanup resilient to already disposed resources
- avoid ObjectDisposedExceptions when shutting down streaming server
- update test cleanup to ignore disposed server

## Testing
- `dotnet build FluxMcp/FluxMcp.csproj`
- `dotnet build FluxMcp.Tests/FluxMcp.Tests.csproj`
- `dotnet test FluxMcp.Tests/FluxMcp.Tests.csproj --no-build`
- `dotnet test FluxMcp.sln --no-build`
