### PR TITLE
Update AGENTS notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Build and test commands run offline once packages are restored. Restoring new packages requires network access.
 - Avoid splitting property values containing paths with spaces across lines, as it can cause path resolution failures.
 - Use `.editorconfig` for configuring compiler warnings and code style settings across the entire solution.
+- Avoid duplicating logic. Centralize reusable code, but don't abstract single-use implementations.
 
 ## Build Configurations
 


### PR DESCRIPTION
## Summary
- clarify bullet on code reuse vs over-centralization

## Testing
- `dotnet test FluxMcp.sln` *(fails: NU1605 package downgrade)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.