### PR TITLE
Fix Resonite refs for stub configs

### DIFF
--- a/ResoniteMod.props
+++ b/ResoniteMod.props
@@ -23,11 +23,11 @@
       <HintPath>$(ResonitePath)rml_libs/ResoniteHotReloadLib.dll</HintPath>
       <Private>$(ResoniteAssemblyPrivate)</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions">
+    <Reference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(Configuration)' != 'StubDebug' and '$(Configuration)' != 'StubRelease'">
       <HintPath>$(ResonitePath)Resonite_Data/Managed/System.Threading.Tasks.Extensions.dll</HintPath>
       <Private>$(ResoniteAssemblyPrivate)</Private>
     </Reference>
-    <Reference Include="System.Memory">
+    <Reference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(Configuration)' != 'StubDebug' and '$(Configuration)' != 'StubRelease'">
       <HintPath>$(ResonitePath)Resonite_Data/Managed/System.Memory.dll</HintPath>
       <Private>$(ResoniteAssemblyPrivate)</Private>
     </Reference>


### PR DESCRIPTION
## Summary
- restrict System.Threading.Tasks.Extensions and System.Memory references to non-stub configs

## Testing
- `dotnet test FluxMcp.sln --no-build --verbosity minimal` *(fails: invalid argument)*
