### PR TITLE
Fix CI build conflict

### DIFF
--- a/ResoniteMod.props
+++ b/ResoniteMod.props
@@ -23,14 +23,6 @@
       <HintPath>$(ResonitePath)rml_libs/ResoniteHotReloadLib.dll</HintPath>
       <Private>$(ResoniteAssemblyPrivate)</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(Configuration)' != 'StubDebug' and '$(Configuration)' != 'StubRelease'">
-      <HintPath>$(ResonitePath)Resonite_Data/Managed/System.Threading.Tasks.Extensions.dll</HintPath>
-      <Private>$(ResoniteAssemblyPrivate)</Private>
-    </Reference>
-    <Reference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(Configuration)' != 'StubDebug' and '$(Configuration)' != 'StubRelease'">
-      <HintPath>$(ResonitePath)Resonite_Data/Managed/System.Memory.dll</HintPath>
-      <Private>$(ResoniteAssemblyPrivate)</Private>
-    </Reference>
   </ItemGroup>
 
   <!-- Use ResoniteStubs for StubDebug/StubRelease builds -->


### PR DESCRIPTION
## Summary
- remove System.Threading.Tasks.Extensions and System.Memory references to avoid type conflicts on Windows

## Testing
- `dotnet test FluxMcp.sln -c StubDebug -v minimal` *(fails: failed to download package)*